### PR TITLE
Enable CORS in server response

### DIFF
--- a/001-qgis-server.conf
+++ b/001-qgis-server.conf
@@ -29,5 +29,10 @@
       # for apache2 > 2.4
       Require all granted
       #Allow from all
+
+      # enable cors
+      Header set Access-Control-Allow-Origin "*"
+      Header set Access-Control-Allow-Methods "POST, GET, OPTIONS, DELETE, PUT"
+      Header set Access-Control-Allow-Headers "authorization,cache-control,expires,pragma"
   </Directory>
  </VirtualHost>

--- a/README.md
+++ b/README.md
@@ -114,5 +114,9 @@ http://internal_lb_ip:1936
 
 > password: stats
 
-
-
+CORS enabled
+------------
+Cors are enabled by default with following headers
+- Access-Control-Allow-Origin "*"
+- Access-Control-Allow-Methods "POST, GET, OPTIONS, DELETE, PUT"
+- Access-Control-Allow-Headers "authorization,cache-control,expires,pragma"

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,9 @@ set -e
 # Apache gets grumpy about PID files pre-existing
 rm -f /usr/local/apache2/logs/httpd.pid
 
+# Add header module to apache
+a2enmod headers
+
 service apache2 restart
 
 # avoid containers closing and keep it open


### PR DESCRIPTION
# Why
Requesting the server is not possible from another domain, response fails because of cors issues.

# How this PR solves this
Start.sh script enables header module for apache2
Server configuration sends cors headers for all responses